### PR TITLE
Optional weight parameter

### DIFF
--- a/acotemplate/include/libaco/ants.h
+++ b/acotemplate/include/libaco/ants.h
@@ -15,11 +15,11 @@
 /// - Elitist Ant System
 /// - Rank-Based Ant System
 /// - Max-Min Ant System
-/// - Ant Colony System 
+/// - Ant Colony System
 ///
 ///For detailed descriptions of these algorithms take a look at the book "Ant Colony Optimization" by Marco Dorigo and Thomas Stuetzle.
 ///
-///  All this was implemented as part of my Master's Thesis at the Technical University of Vienna I'm currently working on with the prospective title 'Ant Colony Optimization for Tree and Hypertree Decomposition'. 
+///  All this was implemented as part of my Master's Thesis at the Technical University of Vienna I'm currently working on with the prospective title 'Ant Colony Optimization for Tree and Hypertree Decomposition'.
 ///
 /// \section getting_started_sec Getting Started
 ///
@@ -126,7 +126,7 @@ class Tour {
 };
 
 /// Interface a client of libaco needs to implement.
-/// 
+///
 /// Interface to the problem-specific logic a client must supply.
 class OptimizationProblem {
   public:
@@ -160,11 +160,11 @@ class OptimizationProblem {
 
     /// Returns the amount of pheromone that shall be deposited onto the edge pointing to v.
     ///
-    /// \param vertex the vertex 
+    /// \param vertex the vertex
     /// \param tour_length the length of the tour.
     /// \return amount of pheromone that shall be laid on the edge to v.
     virtual double pheromone_update(unsigned int vertex, double tour_length) = 0;
-    
+
     /// Callback that notifies the client code that the current ant has added this vertex to it's tour.
     ///
     /// \param vertex that has been added to the tour.
@@ -210,7 +210,7 @@ class Ant {
     virtual void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta) {}
     void construct_rational_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
     void construct_random_proportional_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    virtual void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0) {}
+    virtual void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight) {}
 };
 
 class SimpleAnt : public Ant {
@@ -219,7 +219,7 @@ class SimpleAnt : public Ant {
     SimpleAnt(const SimpleAnt &ant);
     SimpleAnt &operator=(const SimpleAnt &ant);
     void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0);
+    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight);
 };
 
 class ACSAnt : public Ant {
@@ -231,7 +231,7 @@ class ACSAnt : public Ant {
     ACSAnt &operator=(const ACSAnt &ant);
     void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
     void construct_pseudorandom_proportional_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0);
+    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight);
     void set_q0(double q0);
 };
 
@@ -257,6 +257,8 @@ class AntColonyConfiguration {
     double evaporation_rate;
     /// The initial amount of pheromone deposited on the edges.
     double initial_pheromone;
+    /// The constant Q, weight of the pheromone updates
+    double q;
     /// The type of local search to be performed.
     LocalSearchType local_search;
 
@@ -385,6 +387,7 @@ template<class T=Ant, class P=PheromoneMatrix> class AntColony {
     P *pheromones_;
     double alpha_;
     double beta_;
+    double q_;
     AntColonyConfiguration::LocalSearchType local_search_type_;
     std::list<T> *ants_;
     OptimizationProblem *problem_;
@@ -400,6 +403,7 @@ template<class T=Ant, class P=PheromoneMatrix> class AntColony {
       pheromones_ = new P(problem->number_of_vertices()+1, config.evaporation_rate, config.initial_pheromone);
       alpha_ = config.alpha;
       beta_ = config.beta;
+      q_ = config.q;
       local_search_type_ = config.local_search;
       best_so_far_ = new T(problem->get_max_tour_size());
       best_iteration_ = new T(problem->get_max_tour_size());
@@ -481,7 +485,7 @@ class SimpleAntColony : public AntColony<SimpleAnt> {
 /// Implementation of ACO variant "Elitist Ant System".
 ///
 /// In this ACO variant all ants are allowed to deposit pheromone. Additionally
-/// the best-so-far ant is allowed to deposit pheromone multiplied by some 
+/// the best-so-far ant is allowed to deposit pheromone multiplied by some
 /// elitist_weight_ in every iteration. Tours are constructed random-proportionally.
 class ElitistAntColony : public AntColony<SimpleAnt> {
   private:

--- a/acotreewidth/include/libaco/ants.h
+++ b/acotreewidth/include/libaco/ants.h
@@ -15,11 +15,11 @@
 /// - Elitist Ant System
 /// - Rank-Based Ant System
 /// - Max-Min Ant System
-/// - Ant Colony System 
+/// - Ant Colony System
 ///
 ///For detailed descriptions of these algorithms take a look at the book "Ant Colony Optimization" by Marco Dorigo and Thomas Stuetzle.
 ///
-///  All this was implemented as part of my Master's Thesis at the Technical University of Vienna I'm currently working on with the prospective title 'Ant Colony Optimization for Tree and Hypertree Decomposition'. 
+///  All this was implemented as part of my Master's Thesis at the Technical University of Vienna I'm currently working on with the prospective title 'Ant Colony Optimization for Tree and Hypertree Decomposition'.
 ///
 /// \section getting_started_sec Getting Started
 ///
@@ -126,7 +126,7 @@ class Tour {
 };
 
 /// Interface a client of libaco needs to implement.
-/// 
+///
 /// Interface to the problem-specific logic a client must supply.
 class OptimizationProblem {
   public:
@@ -160,11 +160,11 @@ class OptimizationProblem {
 
     /// Returns the amount of pheromone that shall be deposited onto the edge pointing to v.
     ///
-    /// \param vertex the vertex 
+    /// \param vertex the vertex
     /// \param tour_length the length of the tour.
     /// \return amount of pheromone that shall be laid on the edge to v.
     virtual double pheromone_update(unsigned int vertex, double tour_length) = 0;
-    
+
     /// Callback that notifies the client code that the current ant has added this vertex to it's tour.
     ///
     /// \param vertex that has been added to the tour.
@@ -210,7 +210,7 @@ class Ant {
     virtual void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta) {}
     void construct_rational_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
     void construct_random_proportional_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    virtual void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0) {}
+    virtual void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight) {}
 };
 
 class SimpleAnt : public Ant {
@@ -219,7 +219,7 @@ class SimpleAnt : public Ant {
     SimpleAnt(const SimpleAnt &ant);
     SimpleAnt &operator=(const SimpleAnt &ant);
     void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0);
+    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight);
 };
 
 class ACSAnt : public Ant {
@@ -231,7 +231,7 @@ class ACSAnt : public Ant {
     ACSAnt &operator=(const ACSAnt &ant);
     void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
     void construct_pseudorandom_proportional_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0);
+    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight);
     void set_q0(double q0);
 };
 
@@ -257,6 +257,8 @@ class AntColonyConfiguration {
     double evaporation_rate;
     /// The initial amount of pheromone deposited on the edges.
     double initial_pheromone;
+    /// The constant Q, weight of the pheromone updates
+    double q;
     /// The type of local search to be performed.
     LocalSearchType local_search;
 
@@ -385,6 +387,7 @@ template<class T=Ant, class P=PheromoneMatrix> class AntColony {
     P *pheromones_;
     double alpha_;
     double beta_;
+    double q_;
     AntColonyConfiguration::LocalSearchType local_search_type_;
     std::list<T> *ants_;
     OptimizationProblem *problem_;
@@ -400,6 +403,7 @@ template<class T=Ant, class P=PheromoneMatrix> class AntColony {
       pheromones_ = new P(problem->number_of_vertices()+1, config.evaporation_rate, config.initial_pheromone);
       alpha_ = config.alpha;
       beta_ = config.beta;
+      q_ = config.q;
       local_search_type_ = config.local_search;
       best_so_far_ = new T(problem->get_max_tour_size());
       best_iteration_ = new T(problem->get_max_tour_size());
@@ -481,7 +485,7 @@ class SimpleAntColony : public AntColony<SimpleAnt> {
 /// Implementation of ACO variant "Elitist Ant System".
 ///
 /// In this ACO variant all ants are allowed to deposit pheromone. Additionally
-/// the best-so-far ant is allowed to deposit pheromone multiplied by some 
+/// the best-so-far ant is allowed to deposit pheromone multiplied by some
 /// elitist_weight_ in every iteration. Tours are constructed random-proportionally.
 class ElitistAntColony : public AntColony<SimpleAnt> {
   private:

--- a/acotsp/include/libaco/ants.h
+++ b/acotsp/include/libaco/ants.h
@@ -15,11 +15,11 @@
 /// - Elitist Ant System
 /// - Rank-Based Ant System
 /// - Max-Min Ant System
-/// - Ant Colony System 
+/// - Ant Colony System
 ///
 ///For detailed descriptions of these algorithms take a look at the book "Ant Colony Optimization" by Marco Dorigo and Thomas Stuetzle.
 ///
-///  All this was implemented as part of my Master's Thesis at the Technical University of Vienna I'm currently working on with the prospective title 'Ant Colony Optimization for Tree and Hypertree Decomposition'. 
+///  All this was implemented as part of my Master's Thesis at the Technical University of Vienna I'm currently working on with the prospective title 'Ant Colony Optimization for Tree and Hypertree Decomposition'.
 ///
 /// \section getting_started_sec Getting Started
 ///
@@ -126,7 +126,7 @@ class Tour {
 };
 
 /// Interface a client of libaco needs to implement.
-/// 
+///
 /// Interface to the problem-specific logic a client must supply.
 class OptimizationProblem {
   public:
@@ -160,11 +160,11 @@ class OptimizationProblem {
 
     /// Returns the amount of pheromone that shall be deposited onto the edge pointing to v.
     ///
-    /// \param vertex the vertex 
+    /// \param vertex the vertex
     /// \param tour_length the length of the tour.
     /// \return amount of pheromone that shall be laid on the edge to v.
     virtual double pheromone_update(unsigned int vertex, double tour_length) = 0;
-    
+
     /// Callback that notifies the client code that the current ant has added this vertex to it's tour.
     ///
     /// \param vertex that has been added to the tour.
@@ -210,7 +210,7 @@ class Ant {
     virtual void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta) {}
     void construct_rational_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
     void construct_random_proportional_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    virtual void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0) {}
+    virtual void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight) {}
 };
 
 class SimpleAnt : public Ant {
@@ -219,7 +219,7 @@ class SimpleAnt : public Ant {
     SimpleAnt(const SimpleAnt &ant);
     SimpleAnt &operator=(const SimpleAnt &ant);
     void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0);
+    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight);
 };
 
 class ACSAnt : public Ant {
@@ -231,7 +231,7 @@ class ACSAnt : public Ant {
     ACSAnt &operator=(const ACSAnt &ant);
     void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
     void construct_pseudorandom_proportional_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0);
+    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight);
     void set_q0(double q0);
 };
 
@@ -257,6 +257,8 @@ class AntColonyConfiguration {
     double evaporation_rate;
     /// The initial amount of pheromone deposited on the edges.
     double initial_pheromone;
+    /// The constant Q, weight of the pheromone updates
+    double q;
     /// The type of local search to be performed.
     LocalSearchType local_search;
 
@@ -385,6 +387,7 @@ template<class T=Ant, class P=PheromoneMatrix> class AntColony {
     P *pheromones_;
     double alpha_;
     double beta_;
+    double q_;
     AntColonyConfiguration::LocalSearchType local_search_type_;
     std::list<T> *ants_;
     OptimizationProblem *problem_;
@@ -400,6 +403,7 @@ template<class T=Ant, class P=PheromoneMatrix> class AntColony {
       pheromones_ = new P(problem->number_of_vertices()+1, config.evaporation_rate, config.initial_pheromone);
       alpha_ = config.alpha;
       beta_ = config.beta;
+      q_ = config.q;
       local_search_type_ = config.local_search;
       best_so_far_ = new T(problem->get_max_tour_size());
       best_iteration_ = new T(problem->get_max_tour_size());
@@ -481,7 +485,7 @@ class SimpleAntColony : public AntColony<SimpleAnt> {
 /// Implementation of ACO variant "Elitist Ant System".
 ///
 /// In this ACO variant all ants are allowed to deposit pheromone. Additionally
-/// the best-so-far ant is allowed to deposit pheromone multiplied by some 
+/// the best-so-far ant is allowed to deposit pheromone multiplied by some
 /// elitist_weight_ in every iteration. Tours are constructed random-proportionally.
 class ElitistAntColony : public AntColony<SimpleAnt> {
   private:

--- a/acotsp/src/acotsp.cpp
+++ b/acotsp/src/acotsp.cpp
@@ -15,6 +15,7 @@ static unsigned int iterations = UINT_MAX;
 static double alpha = 1.0;
 static double beta = 1.0;
 static double rho = 0.1;
+static double q = 1.0;
 static double initial_pheromone = -1.0;
 static bool print_tour_flag = false;
 static bool stag_variance_flag = false;
@@ -45,6 +46,7 @@ static void parse_options(int argc, char *argv[]) {
   TCLAP::ValueArg<double> alpha_arg ("a", "alpha", "alpha (influence of pheromone trails)", false, alpha, "double");
   TCLAP::ValueArg<double> beta_arg("b", "beta", "beta (influence of heuristic information)", false, beta, "double");
   TCLAP::ValueArg<double> rho_arg("r", "rho", "pheromone trail evaporation rate", false, rho, "double");
+  TCLAP::ValueArg<double> q_arg("q", "q", "Q parameter, weight of pheromone update", false, q, "double");
   TCLAP::ValueArg<double> initial_pheromone_arg("p", "pheromone", "initial pheromone value", false, initial_pheromone, "double");
   std::vector<unsigned int> allowed;
   allowed.push_back(0);
@@ -75,6 +77,7 @@ static void parse_options(int argc, char *argv[]) {
   cmd.add(alpha_arg);
   cmd.add(beta_arg);
   cmd.add(rho_arg);
+  cmd.add(q_arg);
   cmd.add(initial_pheromone_arg);
   cmd.add(filepath_arg);
   cmd.add(print_tour_arg);
@@ -92,6 +95,7 @@ static void parse_options(int argc, char *argv[]) {
   alpha = alpha_arg.getValue();
   beta = beta_arg.getValue();
   rho = rho_arg.getValue();
+  q = q_arg.getValue();
   initial_pheromone = initial_pheromone_arg.getValue();
   filepath = filepath_arg.getValue();
   print_tour_flag = print_tour_arg.getValue();
@@ -123,6 +127,7 @@ static void set_config(AntColonyConfiguration &config) {
   config.beta = beta;
   config.evaporation_rate = rho;
   config.initial_pheromone = initial_pheromone;
+  config.q = q;
 }
 
 static void set_initial_pheromone(OptimizationProblem *problem, AntColonyConfiguration &config) {

--- a/acotsp/src/tsp.cpp
+++ b/acotsp/src/tsp.cpp
@@ -84,6 +84,7 @@ Matrix<unsigned int> *Parser::parse_tsplib(const char *filepath) throw(FileNotFo
     DIMENSION,
     EDGE_WEIGHT_TYPE,
     NODE_COORD_SECTION,
+    EDGE_WEIGHT_SECTION,
     NONE
   };
 
@@ -106,6 +107,8 @@ Matrix<unsigned int> *Parser::parse_tsplib(const char *filepath) throw(FileNotFo
       }
     } else if(keyword.find("NODE_COORD_SECTION") != std::string::npos) {
       s = NODE_COORD_SECTION;
+    } else if(keyword.find("EDGE_WEIGHT_SECTION") != std::string::npos) {
+      s = EDGE_WEIGHT_SECTION;
     }
 
     if (s == DIMENSION) {
@@ -132,7 +135,14 @@ Matrix<unsigned int> *Parser::parse_tsplib(const char *filepath) throw(FileNotFo
           (*distances)[b.num-1][a.num-1] = dab;
         }
       }
+    } else if (s == EDGE_WEIGHT_SECTION) {
+      for(unsigned int i=0;i<distances->rows();i++) {
+        for(unsigned int j=0;j<distances->cols();j++) {
+          file >> (*distances)[i][j];
+        }
+      }
     }
+    
     s = NONE;
   }
   file.close();

--- a/libaco/include/libaco/ants.h
+++ b/libaco/include/libaco/ants.h
@@ -15,11 +15,11 @@
 /// - Elitist Ant System
 /// - Rank-Based Ant System
 /// - Max-Min Ant System
-/// - Ant Colony System 
+/// - Ant Colony System
 ///
 ///For detailed descriptions of these algorithms take a look at the book "Ant Colony Optimization" by Marco Dorigo and Thomas Stuetzle.
 ///
-///  All this was implemented as part of my Master's Thesis at the Technical University of Vienna I'm currently working on with the prospective title 'Ant Colony Optimization for Tree and Hypertree Decomposition'. 
+///  All this was implemented as part of my Master's Thesis at the Technical University of Vienna I'm currently working on with the prospective title 'Ant Colony Optimization for Tree and Hypertree Decomposition'.
 ///
 /// \section getting_started_sec Getting Started
 ///
@@ -126,7 +126,7 @@ class Tour {
 };
 
 /// Interface a client of libaco needs to implement.
-/// 
+///
 /// Interface to the problem-specific logic a client must supply.
 class OptimizationProblem {
   public:
@@ -160,11 +160,11 @@ class OptimizationProblem {
 
     /// Returns the amount of pheromone that shall be deposited onto the edge pointing to v.
     ///
-    /// \param vertex the vertex 
+    /// \param vertex the vertex
     /// \param tour_length the length of the tour.
     /// \return amount of pheromone that shall be laid on the edge to v.
     virtual double pheromone_update(unsigned int vertex, double tour_length) = 0;
-    
+
     /// Callback that notifies the client code that the current ant has added this vertex to it's tour.
     ///
     /// \param vertex that has been added to the tour.
@@ -210,7 +210,7 @@ class Ant {
     virtual void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta) {}
     void construct_rational_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
     void construct_random_proportional_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    virtual void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0) {}
+    virtual void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight) {}
 };
 
 class SimpleAnt : public Ant {
@@ -219,7 +219,7 @@ class SimpleAnt : public Ant {
     SimpleAnt(const SimpleAnt &ant);
     SimpleAnt &operator=(const SimpleAnt &ant);
     void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0);
+    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight);
 };
 
 class ACSAnt : public Ant {
@@ -231,7 +231,7 @@ class ACSAnt : public Ant {
     ACSAnt &operator=(const ACSAnt &ant);
     void construct_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
     void construct_pseudorandom_proportional_solution(OptimizationProblem &op, PheromoneMatrix &pheromones, double alpha, double beta);
-    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight=1.0);
+    void offline_pheromone_update(OptimizationProblem &op, PheromoneMatrix &pheromones, double weight);
     void set_q0(double q0);
 };
 
@@ -257,6 +257,8 @@ class AntColonyConfiguration {
     double evaporation_rate;
     /// The initial amount of pheromone deposited on the edges.
     double initial_pheromone;
+    /// The constant Q, weight of the pheromone updates
+    double q;
     /// The type of local search to be performed.
     LocalSearchType local_search;
 
@@ -385,6 +387,7 @@ template<class T=Ant, class P=PheromoneMatrix> class AntColony {
     P *pheromones_;
     double alpha_;
     double beta_;
+    double q_;
     AntColonyConfiguration::LocalSearchType local_search_type_;
     std::list<T> *ants_;
     OptimizationProblem *problem_;
@@ -400,6 +403,7 @@ template<class T=Ant, class P=PheromoneMatrix> class AntColony {
       pheromones_ = new P(problem->number_of_vertices()+1, config.evaporation_rate, config.initial_pheromone);
       alpha_ = config.alpha;
       beta_ = config.beta;
+      q_ = config.q;
       local_search_type_ = config.local_search;
       best_so_far_ = new T(problem->get_max_tour_size());
       best_iteration_ = new T(problem->get_max_tour_size());
@@ -481,7 +485,7 @@ class SimpleAntColony : public AntColony<SimpleAnt> {
 /// Implementation of ACO variant "Elitist Ant System".
 ///
 /// In this ACO variant all ants are allowed to deposit pheromone. Additionally
-/// the best-so-far ant is allowed to deposit pheromone multiplied by some 
+/// the best-so-far ant is allowed to deposit pheromone multiplied by some
 /// elitist_weight_ in every iteration. Tours are constructed random-proportionally.
 class ElitistAntColony : public AntColony<SimpleAnt> {
   private:

--- a/libaco/src/ants.cpp
+++ b/libaco/src/ants.cpp
@@ -422,6 +422,7 @@ AntColonyConfiguration::AntColonyConfiguration() {
   beta = 5.0;
   evaporation_rate = 0.1;
   initial_pheromone = 1.0;
+  q = 1.0;
   local_search = LS_ITERATION_BEST;
 }
 
@@ -450,7 +451,7 @@ void SimpleAntColony::update_pheromones() {
   pheromones_->evaporate_all();
   for(std::list<SimpleAnt>::iterator it=ants_->begin();it!=ants_->end();it++) {
     SimpleAnt &ant = (*it);
-    ant.offline_pheromone_update(*problem_, *pheromones_);
+    ant.offline_pheromone_update(*problem_, *pheromones_, q_);
   }
 }
 
@@ -463,7 +464,7 @@ void ElitistAntColony::update_pheromones() {
   best_so_far_->offline_pheromone_update(*problem_, *pheromones_, elitist_weight_);
   for(std::list<SimpleAnt>::iterator it=ants_->begin();it!=ants_->end();it++) {
     SimpleAnt &ant = (*it);
-    ant.offline_pheromone_update(*problem_, *pheromones_);
+    ant.offline_pheromone_update(*problem_, *pheromones_, q_);
   }
 }
 
@@ -494,9 +495,9 @@ void MaxMinAntColony::update_pheromones() {
   pheromones_->evaporate_all();
   unsigned int every_n_iter = best_so_far_frequency_;
   if(i % every_n_iter == 0) {
-    best_so_far_->offline_pheromone_update(*problem_, *pheromones_);
+    best_so_far_->offline_pheromone_update(*problem_, *pheromones_, q_);
   } else {
-    best_iteration_->offline_pheromone_update(*problem_, *pheromones_);
+    best_iteration_->offline_pheromone_update(*problem_, *pheromones_, q_);
   }
   i++;
 }
@@ -518,5 +519,5 @@ void ACSAntColony::update_pheromones() {
       pheromones_->evaporate(vertices[i-1], vertices[i]);
     }
   }
-  best_so_far_->offline_pheromone_update(*problem_, *pheromones_);
+  best_so_far_->offline_pheromone_update(*problem_, *pheromones_, q_);
 }


### PR DESCRIPTION
In the original ACO report, there is a parameter Q which is a constant affecting the weight of the pheromone trail updates. This was set to 1.0, but I changed it so it's possible to choose it yourself. I also changed the acotsp so it's possible to read asymmetric tsp instances 